### PR TITLE
[CELADON] Remove vaapi project

### DIFF
--- a/include/bsp-android_ia.xml
+++ b/include/bsp-android_ia.xml
@@ -29,7 +29,7 @@
   <project name="device-intel-common" path="device/intel/common" remote="github" revision="master" />
   <project name="device-intel-build" path="device/intel/build" remote="github" revision="master" />
   <project name="libva" path="vendor/intel/external/project-celadon/libva" remote="github" revision="master" />
-  <project name="vaapi" path="vendor/intel/external/project-celadon/vaapi" remote="github" revision="master" />
+  <!--project name="vaapi" path="vendor/intel/external/project-celadon/vaapi" remote="github" revision="master" /-->
   <project path="hardware/interfaces" name="hardware-interfaces" remote="github" revision="master" />
   <project path="hardware/intel/bootctrl" name="hardware-intel-bootctrl" remote="github" revision="master" >
     <copyfile src="Android_intel.bp" dest="hardware/intel/Android.bp" />


### PR DESCRIPTION
Remove the old media driver vaapi on Celadon.
Jira: None
Test: None

Signed-off-by: Tianmi Chen <tianmi.chen@intel.com>