### PR TITLE
Move the external/gnu-efi to hardware/intel/external/gnu-efi.

### DIFF
--- a/include/bsp-celadon.xml
+++ b/include/bsp-celadon.xml
@@ -17,7 +17,7 @@
   <project name="pciutils" path="external/pciutils" remote="github" revision="master"/>
   <project name="bootable-live-installer" path="bootable/liveinstaller" groups="pdk" remote="github" revision="master" />
   <project name="hardware-intel-kernelflinger" path="hardware/intel/kernelflinger" groups="pdk" remote="github" revision="master" />
-  <project name="external-gnu-efi" path="external/gnu-efi" groups="pdk" remote="github" revision="master" />
+  <project name="external-gnu-efi" path="hardware/intel/external/gnu-efi" groups="pdk" remote="github" revision="master" />
   <project name="device-androidia-mixins" path="device/intel/mixins" remote="github" revision="master" />
   <project name="device-androidia" path="device/intel/project-celadon" remote="github" revision="master" />
   <project name="device-androidia-kernel" path="kernel/project-celadon" remote="github" revision="master" />


### PR DESCRIPTION
Jira: None.
Test: Can build the kernelflinger.

Change-Id: Ife69eaffc01f474b08963415fa82729a6883a288
Signed-off-by: Ming Tan <ming.tan@intel.com>