### PR TITLE
switch trusty branch to omr1 for o/mr1 Celadon

### DIFF
--- a/include/bsp-android_ia.xml
+++ b/include/bsp-android_ia.xml
@@ -43,21 +43,21 @@
   <project name="pub/scm/linux/kernel/git/firmware/linux-firmware" path="vendor/linux/firmware" remote="kernelorg" revision="master" />
 
   <!-- ikgt projects -->
-  <project name="ikgt-core" path="vendor/intel/fw/evmm/ikgt" remote="intel" revision="refs/tags/o_mr1"/>
+  <project name="ikgt-core" path="vendor/intel/fw/evmm/ikgt" remote="intel" revision="trusty"/>
 
   <!-- trusty core projects -->
-  <project name="trusty_external_headers" path="trusty/external/headers" remote="trusty-ia" revision="refs/tags/o_mr1"/>
-  <project name="trusty_external_lk" path="trusty/external/lk"  remote="trusty-ia" revision="refs/tags/o_mr1">
+  <project name="trusty_external_headers" path="trusty/external/headers" remote="trusty-ia" revision="omr1"/>
+  <project name="trusty_external_lk" path="trusty/external/lk"  remote="trusty-ia" revision="omr1">
     <copyfile src="makefile" dest="trusty/makefile"/>
   </project>
-  <project name="trusty_lk_trusty" path="trusty/lk/trusty" remote="trusty-ia" revision="refs/tags/o_mr1"/>
-  <project name="trusty_lib" path="trusty/lib" remote="trusty-ia" revision="refs/tags/o_mr1" sync-c="true"/>
+  <project name="trusty_lk_trusty" path="trusty/lk/trusty" remote="trusty-ia" revision="omr1"/>
+  <project name="trusty_lib" path="trusty/lib" remote="trusty-ia" revision="omr1"/>
 
   <!-- trusty app projects -->
-  <project name="trusty_app_gatekeeper" path="trusty/app/gatekeeper" remote="trusty-ia" revision="refs/tags/o_mr1"/>
-  <project name="trusty_app_keymaster" path="trusty/app/keymaster" remote="trusty-ia" revision="refs/tags/o_mr1"/>
-  <project name="trusty_app_sample" path="trusty/app/sample" remote="trusty-ia" revision="refs/tags/o_mr1"/>
-  <project name="trusty_app_storage" path="trusty/app/storage" remote="trusty-ia" revision="refs/tags/o_mr1"/>
+  <project name="trusty_app_gatekeeper" path="trusty/app/gatekeeper" remote="trusty-ia" revision="omr1"/>
+  <project name="trusty_app_keymaster" path="trusty/app/keymaster" remote="trusty-ia" revision="omr1"/>
+  <project name="trusty_app_sample" path="trusty/app/sample" remote="trusty-ia" revision="omr1"/>
+  <project name="trusty_app_storage" path="trusty/app/storage" remote="trusty-ia" revision="omr1"/>
 
   <!-- Media vendor projects -->
   <project name="mediasdk_release" path="vendor/intel/external/project-celadon/mediasdk_release" remote="github" revision="omr1" />
@@ -68,18 +68,18 @@
   <project name="mediasdk" path="vendor/intel/external/mediasdk_opensource" remote="github" revision="omr1" />
 
   <!-- trusty vendor projects -->
-  <project name="trusty_vendor_google_aosp" path="trusty/vendor/google/aosp" remote="trusty-ia" revision="refs/tags/o_mr1">
+  <project name="trusty_vendor_google_aosp" path="trusty/vendor/google/aosp" remote="trusty-ia" revision="omr1">
     <copyfile src="lk_inc.mk" dest="trusty/lk_inc.mk"/>
   </project>
 
   <!-- trusty sand projects -->
-  <project name="trusty_app_sand" path="trusty/app/sand" remote="trusty-ia" revision="refs/tags/o_mr1"/>
-  <project name="trusty_device_x86_sand" path="trusty/device/x86/sand" remote="trusty-ia" revision="refs/tags/o_mr1"/>
-  <project name="trusty_platform_sand" path="trusty/platform/sand" remote="trusty-ia" revision="refs/tags/o_mr1"/>
-  <project name="trusty_target_sand" path="trusty/target/sand" remote="trusty-ia" revision="refs/tags/o_mr1"/>
+  <project name="trusty_app_sand" path="trusty/app/sand" remote="trusty-ia" revision="omr1"/>
+  <project name="trusty_device_x86_sand" path="trusty/device/x86/sand" remote="trusty-ia" revision="omr1"/>
+  <project name="trusty_platform_sand" path="trusty/platform/sand" remote="trusty-ia" revision="omr1"/>
+  <project name="trusty_target_sand" path="trusty/target/sand" remote="trusty-ia" revision="omr1"/>
 
   <!-- trusty toolchains projects -->
-  <project name="trusty_toolchain" path="vendor/intel/external/prebuilts/elf" remote="trusty-ia" revision="refs/tags/o_mr1"/>
+  <project name="trusty_toolchain" path="vendor/intel/external/prebuilts/elf" remote="trusty-ia" revision="omr1"/>
 
   <!-- Temporary till necessary patches from AOSP master land in Android N branch. We use frameworks-av as a temporary repository for libbcc -->
   <project groups="aosp,pdk" name="platform/hardware/bsp/intel" path="hardware/bsp/intel" revision="refs/tags/android-7.1.1_r6" />


### PR DESCRIPTION
trusty branches out omr1 branch for o/mr1 Celadon.
the patch switches the trusty branch to omr1 for Celadon omr1 manifest

Tracked-On: None
Signed-off-by: roger feng <roger.feng@intel.com>