### PR TITLE
thermal-daemon: Add repo entry in manifest

### DIFF
--- a/include/bsp-celadon.xml
+++ b/include/bsp-celadon.xml
@@ -7,6 +7,7 @@
   <project name="MemTrack" path="vendor/intel/external/project-celadon/memtrack" groups="pdk" remote="github" revision="master"/>
   <!--project name="DPTF" path="vendor/intel/external/project-celadon/dptf" groups="pdk" remote="github" revision="master"/-->
   <!--project name="platform_external_efitools" path="external/efitools" remote="github" revision="master"/-->
+  <project name="thermal_daemon" path="vendor/intel/external/project-celadon/thermal_daemon" remote="intel" revision="master"/>
   <project name="powerhal" path="vendor/intel/external/project-celadon/powerhal" remote="github" revision="master"/>
   <project name="OpenSSL" path="vendor/intel/external/openssl" remote="github" revision="master"/>
   <project name="external-libdrm" path="vendor/intel/external/project-celadon/libdrm" groups="pdk" remote="intel" revision="stable"/>


### PR DESCRIPTION
thermal-daemon is the proposed thermal solution for celadon.
Hence adding the source to the manifest.

Tracked-On: OAM-67241
Signed-off-by: ysiyer <yegnesh.s.iyer@intel.com>