### PR TITLE
[CELADON] Removing parameter_framework_plugins_aosp_audio_route since…

### DIFF
--- a/include/bsp-celadon.xml
+++ b/include/bsp-celadon.xml
@@ -27,7 +27,6 @@
   <project name="hardware_intel_audio" path="vendor/intel/external/project-celadon/audio_pfw/hal" remote="github" revision="master" />
   <project name="hardware_intel_audiocomms_utilities" path="vendor/intel/external/project-celadon/audio_pfw/utilities" remote="github" revision="master" />
   <project name="vendor_intel_hardware_audiocomms_parameter-framework_plugins_alsa" path="vendor/intel/external/project-celadon/audio_pfw/plugins/alsa" remote="github" revision="master" />
-  <project name="parameter_framework_plugins_aosp_audio_route" path="vendor/intel/external/project-celadon/audio_pfw/plugins/aosp_audio_route" remote="github" revision="master" />
   <project name="device-intel-common" path="device/intel/common" remote="github" revision="master" >
      <copyfile dest="vendor/intel/external/Android.bp" src="Android_intel.bp"/>
   </project>


### PR DESCRIPTION
… it is not used

Tracked-On: OAM-69794
Signed-off-by: Swaroop Balan <swaroop.balan@intel.com>