### PR TITLE
[CELADON] Moving Vendor-linux-firmware to kernelorg-master

### DIFF
--- a/include/bsp-celadon.xml
+++ b/include/bsp-celadon.xml
@@ -45,7 +45,7 @@
   </project>
 
     <!-- From public kernel.org -->
-  <project name="vendor-linux-firmware" path="vendor/linux/firmware" remote="github" revision="master" />
+  <project name="pub/scm/linux/kernel/git/firmware/linux-firmware" path="vendor/linux/firmware" remote="kernelorg" revision="master" />
   <!--art-extension -->
   <project name="vendor_intel_art-extension" path="vendor/intel/art-extension" remote="github" revision="stable"/>
   <!-- ikgt projects -->


### PR DESCRIPTION
Change-Id: I2548396fa37d927b014c6e7ba6d287b25a308b75
Tracked-On: https://jira.devtools.intel.com/browse/OAM-84362
Signed-off-by: swaroopb <swaroop.balan@intel.com>