### PR TITLE
[CIC] Migrate bsp/google diff patches to vendor/intel/utils

### DIFF
--- a/include/bsp-cic.xml
+++ b/include/bsp-cic.xml
@@ -34,4 +34,6 @@
   <project name="ikgt-core" path="vendor/intel/fw/evmm" remote="github" revision="master"/>
   <project name="trusty-release-binaries" path="vendor/intel/fw/trusty-release-binaries" remote="github" revision="master"/>
 
+  <project name="vendor-intel-utils" path="vendor/intel/utils" remote="github" revision="celadon/p/mr0/cic" />
+
 </manifest>


### PR DESCRIPTION
Tracked-On: OAM-89816
Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>
Change-Id: I7dd2b773a9971a83c9a1590a272119c334b40f2c