### PR TITLE
Include the open sourced app icon manager git tree.

### DIFF
--- a/include/bsp-celadon.xml
+++ b/include/bsp-celadon.xml
@@ -66,6 +66,7 @@
   <project name="external-mesa" path="hardware/intel/external/mesa3d-intel" remote="github" revision="master" />
   <project name="IA-Hardware-Composer" path="vendor/intel/external/hwcomposer-intel" remote="github" revision="master" />
   <project name="hwc-vhal" path="vendor/intel/external/hwcomposer-vhal" remote="github" revision="master" />
+  <project name="app-icon-manager" path="vendor/intel/app_icon_manager" remote="github" revision="main" />
   <project name="minigbm" path="hardware/intel/external/minigbm-intel"  remote="github" revision="master" />
 
   <project name="linux-intel-lts2019-chromium" path="kernel/lts2019-chromium" remote="github" revision="master" />


### PR DESCRIPTION
Since we open sourced app icon manager into celadon git repo, so
we change the git address to new one accordingly.

Signed-off-by: Wan Shuang <shuang.wan@intel.com>
Traced-On: OAM-98236