### PR TITLE
Hcitools are used only for debugging purpose and hence

### DIFF
--- a/include/bsp-celadon.xml
+++ b/include/bsp-celadon.xml
@@ -23,7 +23,6 @@
   <project name="gmmlib" path="hardware/intel/external/media/gmmlib" remote="github" revision="master"/>
   <project name="hardware-intel-bootctrl" path="hardware/intel/bootctrl" remote="github" revision="master" />
   <project name="hardware-intel-usb" path="hardware/intel/usb" remote="github" revision="master" />
-  <project name="hcitools" path="vendor/intel/external/hcitools-intel" remote="github" revision="master" />
   <project name="hdcp" path="hardware/intel/external/media/hdcp" remote="github" revision="master" />
   <project name="intel-graphics-compiler" path="hardware/intel/external/opencl/intel-graphics-compiler" remote="github" revision="master"/>
   <project name="kernelflinger" path="hardware/intel/kernelflinger" remote="github" revision="master" />


### PR DESCRIPTION
removing it from source code

Tracked-On: OAM-100207
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>