### PR TITLE
Update kernel revision to CFI enabled tag

### DIFF
--- a/include/bsp-celadon.xml
+++ b/include/bsp-celadon.xml
@@ -81,5 +81,5 @@
 
   <project name="app-icon-manager" path="vendor/intel/app_icon_manager" remote="github" revision="main" />
   <project name="linux-intel-lts2020-chromium" path="kernel/lts2020-chromium" remote="github" revision="main"/>
-  <project name="linux-intel-lts2021-chromium" path="kernel/lts2021-chromium" remote="github" revision="main"/>
+  <project name="linux-intel-lts2021-chromium" path="kernel/lts2021-chromium" remote="github" revision="refs/tags/lts-v5.15.44-221031"/>
 </manifest>


### PR DESCRIPTION
Intel Android Platform shall support Android Platform Hardening by
enabling CFI.

Updated lts2021-chromium revision to CFI enabled tag.

Change-Id: I7db15d1021ba036adc7df59bac362506c3216c27
Tracked-On: OAM-104319
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>