### PR TITLE
CVE: Update manifest with latest commit hash for v5.10.118

### DIFF
--- a/include/bsp-celadon.xml
+++ b/include/bsp-celadon.xml
@@ -78,6 +78,6 @@
 	<annotation name="readonly" value="true"/>
   </project>
   <project name="app-icon-manager" path="vendor/intel/app_icon_manager" remote="github" revision="celadon/s/mr0/stable" />
-  <project name="linux-intel-lts2020-chromium" path="kernel/lts2020-chromium" remote="github" revision="celadon/s/mr0/stable" />
+  <project name="linux-intel-lts2020-chromium" path="kernel/lts2020-chromium" remote="github" revision="refs/tags/lts-v5.10.118-20221103-r1" />
   <project name="clipboard-agent" path="vendor/intel/external/clipboard-agent" remote="github" revision="celadon/s/mr0/stable" />
 </manifest>


### PR DESCRIPTION
CVE-2022-21123 - Applied

CVE-2022-21125 - Applied

CVE-2022-21166 - Applied

CVE-2022-1972/CVE-2022-2078 - Applied

CVE-2022-3028 - Applied

CVE-2022-1184 - Applied

CVE-2022-2959 - Applied

CVE-2022-2503 - Applied

CVE-2022-36123 - Applied

CVE-2022-36879 - Applied

CVE-2021-33655 - Applied

CVE-2022-3577 - Applied

CVE-2022-3594 - Applied

CVE-2022-20422 - Applied

CVE-2022-20421 - Applied

Tracked-On: OAM-104461
Signed-off-by: tboppana <tej.kiran.boppana@intel.com>