### PR TITLE
Update the firmware revision to 20240115

### DIFF
--- a/include/bsp-celadon.xml
+++ b/include/bsp-celadon.xml
@@ -84,6 +84,6 @@
   <project name="external-libdrm" path="hardware/intel/external/drm-intel" remote="github" revision="v2.4.115" />
   <project name="external-mesa" path="hardware/intel/external/mesa3d-intel" remote="github" revision="v23.1.1" />
   <project name="minigbm" path="hardware/intel/external/minigbm-intel"  remote="github" revision="upstream_main" />
-  <project name="pub/scm/linux/kernel/git/firmware/linux-firmware" path="vendor/linux/firmware" remote="kernel.googlesource" revision="refs/tags/20231111"/>
+  <project name="pub/scm/linux/kernel/git/firmware/linux-firmware" path="vendor/linux/firmware" remote="kernel.googlesource" revision="refs/tags/20240115"/>
   <project name="kernel-modules" path="kernel/modules" remote="github" revision="master"/>
 </manifest>


### PR DESCRIPTION
Updating the firmware revision to ensure proper functioning of Wi-Fi.

Tests done:
- Flashing and booting for CIV in GVT-d
- Enabling Wi-Fi and connecting to it

Change-Id: Ic7c7af952efe88a25e51deb546b8e6ecdfa082da
Tracked-On: OAM-115437