### PR TITLE
Upgrade AOSP tag from r21 to r24

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -3,7 +3,7 @@
 
    <remote  name="aosp"
             fetch="https://android-review.googlesource.com" />
-   <default revision="refs/tags/android-14.0.0_r17"
+   <default revision="refs/tags/android-14.0.0_r24"
             remote="aosp"
             sync-j="4" />
 

--- a/include/aosp_vanilla.xml
+++ b/include/aosp_vanilla.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <superproject name="platform/superproject" remote="aosp" revision="android-14.0.0_r21"/>
+  <superproject name="platform/superproject" remote="aosp" revision="android-14.0.0_r24"/>
   <contactinfo bugurl="go/repo-bug" />
   <project path="build/make" name="platform/build" groups="pdk" >
     <linkfile src="CleanSpec.mk" dest="build/CleanSpec.mk" />


### PR DESCRIPTION
This patch will upgrade the AOSP tag from r21 to r24

Tests-Done: Build and boot android successfully.
	    Wi-Fi connected and working
	    app installation launch and run test done.

Tracked-On: OAM-115630