### PR TITLE
Removal of unused 5.15 kernel

### DIFF
--- a/include/bsp-celadon.xml
+++ b/include/bsp-celadon.xml
@@ -59,8 +59,6 @@
   <project name="vm-manager-binaries" path="device/intel/civ/host/vm-manager-binaries" remote="github" revision="celadon/u/mr0/master" />
 
   <project name="app-icon-manager" path="vendor/intel/app_icon_manager" remote="github" revision="celadon/u/mr0/master" />
-  <project name="linux-intel-lts2021-chromium" path="kernel/lts2021-chromium" remote="github" revision="celadon/u/mr0/master"/>
-  <project name="linux-intel-lts2021" path="kernel/linux-intel-lts2021" remote="github" revision="celadon/u/mr0/master"/>
   <project name="linux-intel-lts2022" path="kernel/linux-intel-lts2022" remote="github" revision="celadon/u/mr0/master"/>
   <project name="clipboard-agent" path="vendor/intel/external/clipboard-agent" remote="github" revision="celadon/u/mr0/master" />
   <project name="linux-intel-lts2022-chromium" path="kernel/lts2022-chromium" remote="github" revision="celadon/u/mr0/master"/>


### PR DESCRIPTION
Removing the following unsupported kernels from manifest file:
- linux-intel-lts2021
- lts2021-chromium

Tests done:
- Android CIV
- Wi-Fi on/off/scan
- Bluetooth on/off/scan
- Camera capture/recording
- adb reboot
- adb remount in CIV

Tracked-On: OAM-125213
Change-Id: I55c8765aa27589532fd924ad021392d63e320f9d