### PR TITLE
Add linux-npu-driver

### DIFF
--- a/include/bsp-celadon.xml
+++ b/include/bsp-celadon.xml
@@ -82,4 +82,5 @@
   <project name="pub/scm/linux/kernel/git/firmware/linux-firmware" path="vendor/linux/firmware" remote="kernel.googlesource" revision="refs/tags/20240709" />
   <project name="kernel-modules" path="kernel/modules" remote="github" revision="master"/>
   <project name="oneapi-integration" path="vendor/intel/oneapi-integration" remote="github" revision="main" />
+  <project name="linux-npu-driver" path="hardware/intel/external/linux-npu-driver" remote="github.intel" revision="refs/tags/v1.8.0"/>
 </manifest>


### PR DESCRIPTION
Added linux-npu-driver for firmware.

Tests done:
- Android build
- Boot and verified npu device /dev/accel0 enumeration.


Tracked-On: OAM-126050